### PR TITLE
Add support for multiple AZs

### DIFF
--- a/.github/workflows/zkevm-circuits.yml
+++ b/.github/workflows/zkevm-circuits.yml
@@ -13,7 +13,7 @@ jobs:
       GH_PAT: ${{ secrets.GH_PAT }}
       IMAGE_ID: ami-07ac3f6ac10eb4c13
       KEY_NAME: devops
-      SUBNET_ID: subnet-0a992add1642a4aaa
+      SUBNET_ID: "subnet-0a992add1642a4aaa subnet-03258a57327ae4d25 subnet-0cd717f7a7760481b"
       SECURITY_GROUP_ID: sg-080ef15f20c28bc59
       REPO: privacy-scaling-explorations/zkevm-circuits
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR implements the functionality to deploy ephemeral runners to multiple availability zones, so we can spread resources among them, and avoid a scenario where AWS does not have enough available on demand capacity to a specific AZ.